### PR TITLE
Speed up snap_keyframe a lot

### DIFF
--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1266,9 +1266,9 @@ class ORM:
 				assert copy_to_branch != now[0]
 				whens.append((copy_to_branch, now[1], now[2]))
 			for when in whens:
-				assert (graph, *when) not in kfl
-				nkfs.append((graph, *when, node_val_keyframe,
-								edge_val_keyframe, graph_val_keyframe))
+				nkfs.append(
+					(graph, *when, node_val_keyframe[graph],
+						edge_val_keyframe[graph], graph_val_keyframe[graph]))
 				kfl.append((graph, *when))
 				kfs.add(when)
 				branch, turn, tick = when

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1245,8 +1245,9 @@ class ORM:
 							return time_from[0], turn, tick
 		parent, turn_from, tick_from, turn_to, tick_to = self._branches[
 			time_from[0]]
-		(parent, turn_from, tick_from) = self._recurse_delta_keyframes(
-			(parent, turn_from, tick_from))
+		if parent is not None:
+			(parent, turn_from, tick_from) = self._recurse_delta_keyframes(
+				(parent, turn_from, tick_from))
 		self._snap_keyframe_from_delta(
 			(parent, turn_from, tick_from),
 			(parent, time_from[1], time_from[2]),

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1068,11 +1068,17 @@ class ORM:
 		for graph, node in nvck:
 			if graph not in node_val_keyframe:
 				node_val_keyframe[graph] = {}
-			node_val_keyframe[graph][node] = nvck[graph, node][then[0]][
-				then[1]][then[2]].copy()
+			try:
+				node_val_keyframe[graph][node] = nvck[graph, node][then[0]][
+					then[1]][then[2]].copy()
+			except KeyError:
+				continue
 		eck = self._edges_cache.keyframe
 		for graph, orig, dest in eck:
-			exists = eck[graph, orig, dest][then[0]][then[1]][then[2]][0]
+			try:
+				exists = eck[graph, orig, dest][then[0]][then[1]][then[2]][0]
+			except KeyError:
+				continue
 			if graph in edges_keyframe:
 				if orig in edges_keyframe[graph]:
 					edges_keyframe[graph][orig][dest] = exists
@@ -1083,8 +1089,11 @@ class ORM:
 		evck = self._edge_val_cache.keyframe
 		for graph, orig, dest, idx in evck:
 			assert idx == 0  # until I get to multigraphs
-			val = evck[graph, orig, dest,
-						idx][then[0]][then[1]][then[2]].copy()
+			try:
+				val = evck[graph, orig, dest,
+							idx][then[0]][then[1]][then[2]].copy()
+			except KeyError:
+				continue
 			if graph in edge_val_keyframe:
 				if orig in edge_val_keyframe:
 					edge_val_keyframe[graph][orig][dest] = val

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1092,7 +1092,7 @@ class ORM:
 					edge_val_keyframe[graph][orig] = {dest: val}
 			else:
 				edge_val_keyframe[graph] = {orig: {dest: val}}
-		for graph in ['phys']:
+		for graph in self.graph.keys() & delta.keys():
 			try:
 				nodes_keyframe[graph] = self._nodes_cache.keyframe[graph, ][
 					then[0]][then[1]][then[2]].copy()

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1291,8 +1291,7 @@ class ORM:
 			the_kf = self._recurse_delta_keyframes((branch, turn, tick))
 			return self._snap_keyframe_from_delta(the_kf, (branch, turn, tick),
 													self.get_delta(
-														the_kf,
-														(branch, turn, tick)),
+														*the_kf, turn, tick),
 													copy_to_branch=branch)
 		self._snap_keyframe_from_delta(the_kf, (branch, turn, tick),
 										self.get_delta(*the_kf, turn, tick))

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1138,10 +1138,13 @@ class ORM:
 			if 'nodes' in deltg:
 				if graph in nodes_keyframe:
 					nkg = nodes_keyframe[graph]
+					nvkg = node_val_keyframe.setdefault(graph, {})
 					for node, exists in deltg['nodes'].items():
 						if node in nkg:
 							if not exists:
 								del nkg[node]
+								if node in nvkg:
+									del nvkg[node]
 						elif exists:
 							nkg[node] = True
 				else:
@@ -1192,13 +1195,17 @@ class ORM:
 								now[2]: val
 							}
 			if 'edges' in deltg:
-				if graph not in edges_keyframe:
-					edges_keyframe[graph] = {}
-				ekg = edges_keyframe[graph]
+				ekg = edges_keyframe.setdefault(graph, {})
+				evkg = edge_val_keyframe.setdefault(graph, {})
 				for (orig, dest), exists in deltg['edges'].items():
 					if orig in ekg:
 						if exists:
 							ekg[orig][dest] = exists
+						else:
+							if dest in ekg[orig]:
+								del ekg[orig][dest]
+							if orig in evkg and dest in evkg[orig]:
+								del evkg[orig][dest]
 					elif exists:
 						ekg[orig] = {dest: exists}
 				for orig, dests in edges_keyframe[graph].items():

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1172,7 +1172,12 @@ class ORM:
 						else:
 							ekg[orig] = dests
 				else:
-					edges_keyframe[graph] = deltg['edges']
+					ekg = edges_keyframe[graph] = {}
+					for (orig, dest), exists in deltg['edges'].items():
+						if orig in ekg:
+							ekg[orig][dest] = exists
+						else:
+							ekg[orig] = {dest: exists}
 				for orig, dests in edges_keyframe[graph].items():
 					for dest, ex in dests.items():
 						if now[1] in eck[graph, orig, dest][now[0]]:

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1307,7 +1307,10 @@ class ORM:
 		if branch in kfd:
 			# I could probably avoid sorting these by using windowdicts
 			for trn in sorted(kfd[branch].keys(), reverse=True):
-				if trn <= turn:
+				if trn < turn:
+					the_kf = (branch, trn, max(kfd[branch][trn]))
+					break
+				elif trn == turn:
 					for tck in sorted(kfd[branch][trn], reverse=True):
 						if tck <= tick:
 							the_kf = (branch, trn, tck)

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -939,6 +939,7 @@ class ORM:
 		nkfs = self._new_keyframes
 		whens = [(branch, turn, tick)]
 		if copy_to_branch is not None:
+			assert copy_to_branch != branch
 			whens.append((copy_to_branch, turn, tick))
 		for graphn, graph in self.graph.items():
 			nodes = graph._nodes_state()
@@ -1316,10 +1317,7 @@ class ORM:
 		if the_kf is None:
 			parent, _, _, turn_to, tick_to = self._branches[branch]
 			if parent is None:
-				return self._snap_keyframe_de_novo(branch,
-													turn,
-													tick,
-													copy_to_branch=branch)
+				return self._snap_keyframe_de_novo(branch, turn, tick)
 			the_kf = self._recurse_delta_keyframes((branch, turn, tick))
 			return self._snap_keyframe_from_delta(the_kf, (branch, turn, tick),
 													self.get_delta(

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1273,9 +1273,9 @@ class ORM:
 				assert copy_to_branch != now[0]
 				whens.append((copy_to_branch, now[1], now[2]))
 			for when in whens:
-				nkfs.append(
-					(graph, *when, node_val_keyframe[graph],
-						edge_val_keyframe[graph], graph_val_keyframe[graph]))
+				nkfs.append((graph, *when, node_val_keyframe.get(graph, {}),
+								edge_val_keyframe.get(graph, {}),
+								graph_val_keyframe.get(graph, {})))
 				kfl.append((graph, *when))
 				kfs.add(when)
 				branch, turn, tick = when

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1260,7 +1260,7 @@ class ORM:
 								edge_val_keyframe, graph_val_keyframe))
 				kfl.append((graph, *when))
 				kfs.add(when)
-				branch, turn, tick = now
+				branch, turn, tick = when
 				if branch not in kfd:
 					kfd[branch] = {
 						turn: {

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1137,9 +1137,18 @@ class ORM:
 						now[1]][now[2]] = graph_val_keyframe[graph]
 			if 'nodes' in deltg:
 				if graph in nodes_keyframe:
-					nodes_keyframe[graph].update(deltg['nodes'])
+					nkg = nodes_keyframe[graph]
+					for node, exists in deltg['nodes'].items():
+						if node in nkg:
+							if not exists:
+								del nkg[node]
+						elif exists:
+							nkg[node] = True
 				else:
-					nodes_keyframe[graph] = deltg['nodes']
+					nodes_keyframe[graph] = {
+						node: exists
+						for node, exists in deltg['nodes'].items() if exists
+					}
 				nckg = self._nodes_cache.keyframe[graph, ]
 				if now[1] in nckg[now[0]]:
 					nckg[now[0]][now[1]][now[2]] = nodes_keyframe[graph]
@@ -1188,8 +1197,9 @@ class ORM:
 				ekg = edges_keyframe[graph]
 				for (orig, dest), exists in deltg['edges'].items():
 					if orig in ekg:
-						ekg[orig][dest] = exists
-					else:
+						if exists:
+							ekg[orig][dest] = exists
+					elif exists:
 						ekg[orig] = {dest: exists}
 				for orig, dests in edges_keyframe[graph].items():
 					for dest, ex in dests.items():

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1248,11 +1248,11 @@ class ORM:
 		if parent is not None:
 			(parent, turn_from, tick_from) = self._recurse_delta_keyframes(
 				(parent, turn_from, tick_from))
-		self._snap_keyframe_from_delta(
-			(parent, turn_from, tick_from),
-			(parent, time_from[1], time_from[2]),
-			self.get_delta(parent, turn_from, tick_from, time_from[1],
-							time_from[2]), time_from[0])
+			self._snap_keyframe_from_delta(
+				(parent, turn_from, tick_from),
+				(parent, time_from[1], time_from[2]),
+				self.get_delta(parent, turn_from, tick_from, time_from[1],
+								time_from[2]), time_from[0])
 		return time_from
 
 	@world_locked

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1164,20 +1164,14 @@ class ORM:
 								now[2]: val
 							}
 			if 'edges' in deltg:
-				if graph in edges_keyframe:
-					ekg = edges_keyframe[graph]
-					for orig, dests in deltg['edges'].items():
-						if orig in ekg:
-							ekg[orig].update(dests)
-						else:
-							ekg[orig] = dests
-				else:
-					ekg = edges_keyframe[graph] = {}
-					for (orig, dest), exists in deltg['edges'].items():
-						if orig in ekg:
-							ekg[orig][dest] = exists
-						else:
-							ekg[orig] = {dest: exists}
+				if graph not in edges_keyframe:
+					edges_keyframe[graph] = {}
+				ekg = edges_keyframe[graph]
+				for (orig, dest), exists in deltg['edges'].items():
+					if orig in ekg:
+						ekg[orig][dest] = exists
+					else:
+						ekg[orig] = {dest: exists}
 				for orig, dests in edges_keyframe[graph].items():
 					for dest, ex in dests.items():
 						if now[1] in eck[graph, orig, dest][now[0]]:

--- a/LiSE/LiSE/allegedb/window.py
+++ b/LiSE/LiSE/allegedb/window.py
@@ -577,6 +577,16 @@ class WindowDict(MutableMapping):
 	def __bool__(self) -> bool:
 		return bool(self._past) or bool(self._future)
 
+	def copy(self):
+		empty = WindowDict.__new__(WindowDict)
+		empty._past = self._past.copy()
+		empty._future = self._future.copy()
+		empty._keys = self._keys.copy()
+		empty.beginning = self.beginning
+		empty.end = self.end
+		empty._last = self._last
+		return empty
+
 	def __init__(
 			self,
 			data: Union[List[Tuple[int, Any]], Dict[int, Any]] = None) -> None:

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -1428,12 +1428,17 @@ class Engine(AbstractEngine, gORM):
 			return v
 		return self.alias(v, stat)
 
-	def _snap_keyframe(self, graph: Hashable, branch: str, turn: int,
-						tick: int, nodes: NodeValDictType,
-						edges: EdgeValDictType,
-						graph_val: StatDictType) -> None:
-		super()._snap_keyframe(graph, branch, turn, tick, nodes, edges,
-								graph_val)
+	def _snap_keyframe_de_novo_graph(self,
+										graph: Hashable,
+										branch: str,
+										turn: int,
+										tick: int,
+										nodes: NodeValDictType,
+										edges: EdgeValDictType,
+										graph_val: StatDictType,
+										copy_to_branch: str = None) -> None:
+		super()._snap_keyframe_de_novo_graph(graph, branch, turn, tick, nodes,
+												edges, graph_val)
 		newkf = {}
 		contkf = {}
 		for (name, node) in nodes.items():


### PR DESCRIPTION
Now the `snap_keyframe` method will take advantage of the fast delta algorithm to update the previous keyframe rapidly.

The engine previously appeared to hang when snapping a keyframe on a grid of, say, 100x100. It was actually just performing *that* badly. It's not bad now.