### PR TITLE
Fast inter-branch time travel

### DIFF
--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1313,7 +1313,9 @@ class ORM:
 							return time_from[0], turn, tick
 		parent, turn_from, tick_from, turn_to, tick_to = self._branches[
 			time_from[0]]
-		if parent is not None:
+		if parent is None:
+			self._snap_keyframe_de_novo(*time_from)
+		else:
 			(parent, turn_from, tick_from) = self._recurse_delta_keyframes(
 				(parent, turn_from, tick_from))
 			self._snap_keyframe_from_delta(

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1299,17 +1299,14 @@ class ORM:
 		else:
 			(parent, turn_from, tick_from) = self._recurse_delta_keyframes(
 				(parent, turn_from, tick_from))
-			if (parent, turn_from, tick_from) == (parent, time_from[1],
+			if (parent, turn_from, tick_from) != (parent, time_from[1],
 													time_from[2]):
-				self._alias_kf(parent, *time_from)
-			else:
 				self._snap_keyframe_from_delta(
 					(parent, turn_from, tick_from),
 					(parent, time_from[1], time_from[2]),
 					self.get_delta(parent, turn_from, tick_from, time_from[1],
 									time_from[2]))
-				self._alias_kf(parent, time_from[0], time_from[1],
-								time_from[2])
+			self._alias_kf(parent, *time_from)
 		return time_from
 
 	@world_locked

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1243,7 +1243,7 @@ class ORM:
 				else:
 					gvckg[now[0]][now[1]] = {now[2]: graph_val_keyframe[graph]}
 				if copy_to_branch is not None:
-					if now[1] in gvckg[now[0]]:
+					if now[1] in gvckg[copy_to_branch]:
 						gvckg[copy_to_branch][now[1]][
 							now[2]] = graph_val_keyframe[graph]
 					else:

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1299,8 +1299,8 @@ class ORM:
 		else:
 			(parent, turn_from, tick_from) = self._recurse_delta_keyframes(
 				(parent, turn_from, tick_from))
-			if (parent, turn_from, tick_from) != (parent, time_from[1],
-													time_from[2]):
+			if (parent, time_from[1],
+				time_from[2]) not in self._keyframes_times:
 				self._snap_keyframe_from_delta(
 					(parent, turn_from, tick_from),
 					(parent, time_from[1], time_from[2]),

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1050,35 +1050,50 @@ class ORM:
 	def _alias_kf(self, branch_from, branch_to, turn, tick):
 		gvck = self._graph_val_cache.keyframe
 		for gvckg in gvck.values():
-			vals = gvckg[branch_from][turn][tick]
+			try:
+				vals = gvckg[branch_from][turn][tick]
+			except KeyError:
+				continue
 			if turn not in gvckg[branch_to]:
 				gvckg[branch_to][turn] = {tick: vals}
 			else:
 				gvckg[branch_to][turn][tick] = vals
 		nck = self._nodes_cache.keyframe
 		for nckg in nck.values():
-			nodes = nckg[branch_from][turn][tick]
+			try:
+				nodes = nckg[branch_from][turn][tick]
+			except KeyError:
+				continue
 			if turn not in nckg[branch_to]:
 				nckg[branch_to][turn] = {tick: nodes}
 			else:
 				nckg[branch_to][turn][tick] = nodes
 		nvck = self._node_val_cache.keyframe
 		for gn in nvck.values():
-			vals = gn[branch_from][turn][tick]
+			try:
+				vals = gn[branch_from][turn][tick]
+			except KeyError:
+				continue
 			if turn not in gn[branch_to]:
 				gn[branch_to][turn] = {tick: vals}
 			else:
 				gn[branch_to][turn][tick] = vals
 		eck = self._edges_cache.keyframe
 		for gorigdest in eck.values():
-			edge = gorigdest[branch_from][turn][tick]
+			try:
+				edge = gorigdest[branch_from][turn][tick]
+			except KeyError:
+				continue
 			if turn not in gorigdest[branch_to]:
 				gorigdest[branch_to][turn] = {tick: edge}
 			else:
 				gorigdest[branch_to][turn][tick] = edge
 		evck = self._edge_val_cache.keyframe
 		for godi in evck.values():
-			vals = godi[branch_from][turn][tick]
+			try:
+				vals = godi[branch_from][turn][tick]
+			except KeyError:
+				continue
 			if turn not in godi[branch_to]:
 				godi[branch_to][turn] = {tick: vals}
 			else:

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -1076,7 +1076,7 @@ class ORM:
 					edge_val_keyframe[graph][orig] = {dest: val}
 			else:
 				edge_val_keyframe[graph] = {orig: {dest: val}}
-		for graph in self.graph.keys() & delta.keys():
+		for graph in self.graph.keys():
 			try:
 				nodes_keyframe[graph] = self._nodes_cache.keyframe[graph, ][
 					then[0]][then[1]][then[2]].copy()
@@ -1089,7 +1089,7 @@ class ORM:
 				graph_val_keyframe[graph] = {}
 			# apply the delta to the keyframes, then save the keyframes back
 			# into the caches, and possibly copy them to another branch as well
-			deltg = delta[graph]
+			deltg = delta.get(graph, {})
 			if 'nodes' in deltg:
 				dn = deltg.pop('nodes')
 				if graph in nodes_keyframe:
@@ -1108,6 +1108,7 @@ class ORM:
 						node: exists
 						for node, exists in dn.items() if exists
 					}
+			if graph in nodes_keyframe:
 				nckg = self._nodes_cache.keyframe[graph, ]
 				if now[1] in nckg[now[0]]:
 					nckg[now[0]][now[1]][now[2]] = nodes_keyframe[graph]
@@ -1137,6 +1138,7 @@ class ORM:
 							nvg[node] = value
 				else:
 					node_val_keyframe[graph] = dnv
+			if graph in node_val_keyframe:
 				nvck = self._node_val_cache.keyframe
 				for node, val in node_val_keyframe[graph].items():
 					if now[1] in nvck[graph, node][now[0]]:
@@ -1166,6 +1168,7 @@ class ORM:
 								del evkg[orig][dest]
 					elif exists:
 						ekg[orig] = {dest: exists}
+			if graph in edges_keyframe:
 				for orig, dests in edges_keyframe[graph].items():
 					for dest, ex in dests.items():
 						if now[1] in eck[graph, orig, dest][now[0]]:
@@ -1208,6 +1211,7 @@ class ORM:
 							evkg[orig] = dests
 				else:
 					edge_val_keyframe[graph] = dgev
+			if graph in edge_val_keyframe:
 				for orig, dests in edge_val_keyframe[graph].items():
 					for dest, val in dests.items():
 						if now[1] in evck[graph, orig, dest, 0][now[0]]:
@@ -1232,6 +1236,7 @@ class ORM:
 					graph_val_keyframe[graph].update(deltg)
 				else:
 					graph_val_keyframe[graph] = deltg
+			if graph in graph_val_keyframe:
 				gvckg = self._graph_val_cache.keyframe[graph, ]
 				if now[1] in gvckg[now[0]]:
 					gvckg[now[0]][now[1]][now[2]] = graph_val_keyframe[graph]

--- a/LiSE/LiSE/allegedb/__init__.py
+++ b/LiSE/LiSE/allegedb/__init__.py
@@ -889,6 +889,51 @@ class ORM:
 		if cache_arranger:
 			self._cache_arrange_thread.start()
 
+	def _get_kf(self, branch, turn, tick):
+		ret = {
+			'graph_val': {},
+			'nodes': {},
+			'node_val': {},
+			'edges': {},
+			'edge_val': {}
+		}
+		gvck = self._graph_val_cache.keyframe
+		gv = ret['graph_val']
+		for k in gvck:
+			try:
+				gv[k] = gvck[k][branch][turn][tick]
+			except KeyError:
+				pass
+		nck = self._nodes_cache.keyframe
+		n = ret['nodes']
+		for k in nck:
+			try:
+				n[k] = nck[k][branch][turn][tick]
+			except KeyError:
+				pass
+		nvck = self._node_val_cache.keyframe
+		nv = ret['node_val']
+		for k in nvck:
+			try:
+				nv[k] = nvck[k][branch][turn][tick]
+			except KeyError:
+				pass
+		eck = self._edges_cache.keyframe
+		e = ret['edges']
+		for k in eck:
+			try:
+				e[k] = eck[k][branch][turn][tick]
+			except KeyError:
+				pass
+		evck = self._edge_val_cache.keyframe
+		ev = ret['edge_val']
+		for k in evck:
+			try:
+				ev[k] = evck[k][branch][turn][tick]
+			except KeyError:
+				pass
+		return ret
+
 	def _init_load(self) -> None:
 		keyframes_list = self._keyframes_list
 		keyframes_dict = self._keyframes_dict

--- a/LiSE/LiSE/allegedb/cache.py
+++ b/LiSE/LiSE/allegedb/cache.py
@@ -632,6 +632,9 @@ class Cache:
 					for ((branc, turn, tick), (parent, entity,
 												key)) in time_entity.items()
 					if branc == branch}
+		todel_shallow = {k for k in self.shallowest if k[-2] == branch}
+		for k in todel_shallow:
+			del self.shallowest[k]
 		for branc, turn, tick, parent, entity, key in todel:
 			self._remove_btt_parentikey(branc, turn, tick, parent, entity, key)
 			if (*parent, entity, key, branc, turn, tick) in self.shallowest:

--- a/LiSE/LiSE/allegedb/cache.py
+++ b/LiSE/LiSE/allegedb/cache.py
@@ -618,14 +618,12 @@ class Cache:
 												key)) in time_entity.items()
 					if (parent and parent[0] == character) or (
 						not parent and entity == character)}
-		todel_shallow = set()
+		todel_shallow = {k for k in self.shallowest if k[0] == character}
+		for k in todel_shallow:
+			del self.shallowest[k]
 		for (branch, turn, tick, parent, entity, key) in todel:
 			self._remove_btt_parentikey(branch, turn, tick, parent, entity,
 										key)
-			todel_shallow.update(k for k in self.shallowest
-									if k[:-3] == (*parent, entity, key))
-		for k in todel_shallow:
-			del self.shallowest[k]
 
 	def remove_branch(self, branch: str):
 		(time_entity, parents, branches, keys, settings, presettings,

--- a/LiSE/LiSE/allegedb/cache.py
+++ b/LiSE/LiSE/allegedb/cache.py
@@ -610,40 +610,48 @@ class Cache:
 		if not db._no_kc:
 			update_keycache(*args, forward=forward)
 
+	def remove_character(self, character):
+		(time_entity, parents, branches, keys, settings, presettings,
+			remove_keycache, keycache) = self._remove_stuff
+		todel = {(branch, turn, tick, parent, entity, key)
+					for ((branch, turn, tick), (parent, entity,
+												key)) in time_entity.items()
+					if (parent and parent[0] == character) or (
+						not parent and entity == character)}
+		todel_shallow = set()
+		for (branch, turn, tick, parent, entity, key) in todel:
+			self._remove_btt_parentikey(branch, turn, tick, parent, entity,
+										key)
+			todel_shallow.update(k for k in self.shallowest
+									if k[:-3] == (*parent, entity, key))
+		for k in todel_shallow:
+			del self.shallowest[k]
+
 	def remove_branch(self, branch: str):
 		(time_entity, parents, branches, keys, settings, presettings,
 			remove_keycache, keycache) = self._remove_stuff
-		parentikeys = set()
-		for (branc, turn, tick), parentikey in list(time_entity.items()):
-			if branc != branch:
-				continue
-			parentikeys.add(parentikey)
-			del time_entity[branc, turn, tick]
-		for (parent, entity, key) in parentikeys:
-			branchkey = parent + (entity, key)
-			keykey = parent + (entity, )
-			if parent in parents:
-				parentt = parents[parent]
-				if entity in parentt:
-					entty = parentt[entity]
-					if key in entty:
-						kee = entty[key]
-						if branch in kee:
-							del kee[branch]
-						if not kee:
-							del entty[key]
-					if not entty:
-						del parentt[entity]
-				if not parentt:
-					del parents[parent]
-			if branchkey in branches:
-				entty = branches[branchkey]
-				if branch in entty:
-					del entty[branch]
-				if not entty:
-					del branches[branchkey]
-			if keykey in keys:
-				entty = keys[keykey]
+		todel = {(branc, turn, tick, parent, entity, key)
+					for ((branc, turn, tick), (parent, entity,
+												key)) in time_entity.items()
+					if branc == branch}
+		for branc, turn, tick, parent, entity, key in todel:
+			self._remove_btt_parentikey(branc, turn, tick, parent, entity, key)
+			if (*parent, entity, key, branc, turn, tick) in self.shallowest:
+				del self.shallowest[(*parent, entity, key, branc, turn, tick)]
+
+	def _remove_btt_parentikey(self, branch, turn, tick, parent, entity, key):
+		(time_entity, parents, branches, keys, settings, presettings,
+			remove_keycache, keycache) = self._remove_stuff
+		try:
+			del time_entity[branch][turn][tick]
+		except KeyError:
+			pass
+		branchkey = parent + (entity, key)
+		keykey = parent + (entity, )
+		if parent in parents:
+			parentt = parents[parent]
+			if entity in parentt:
+				entty = parentt[entity]
 				if key in entty:
 					kee = entty[key]
 					if branch in kee:
@@ -651,10 +659,25 @@ class Cache:
 					if not kee:
 						del entty[key]
 				if not entty:
-					del keys[keykey]
-		del settings[branch]
-		del presettings[branch]
-		self.shallowest = OrderedDict()
+					del parentt[entity]
+			if not parentt:
+				del parents[parent]
+		if branchkey in branches:
+			entty = branches[branchkey]
+			if branch in entty:
+				del entty[branch]
+			if not entty:
+				del branches[branchkey]
+		if keykey in keys:
+			entty = keys[keykey]
+			if key in entty:
+				kee = entty[key]
+				if branch in kee:
+					del kee[branch]
+				if not kee:
+					del entty[key]
+			if not entty:
+				del keys[keykey]
 
 	def remove(self, branch: str, turn: int, tick: int):
 		"""Delete all data from a specific tick"""

--- a/LiSE/LiSE/engine.py
+++ b/LiSE/LiSE/engine.py
@@ -572,6 +572,7 @@ class Engine(AbstractEngine, gORM):
 			self.method = FunctionStore(self._method_file)
 		self.rule = AllRules(self)
 		self.rulebook = AllRuleBooks(self)
+		self._char_caches = self._caches + [self._things_cache]
 
 	def _load_graphs(self) -> None:
 		for charn in self.query.characters():

--- a/LiSE/LiSE/handle.py
+++ b/LiSE/LiSE/handle.py
@@ -634,16 +634,13 @@ class EngineHandle(object):
 		if btt_from == btt_to:
 			return delta
 		now = self._real._btt()
-		if btt_from not in self._real._keyframes_times:
-			self._real._set_btt(*btt_from)
-			self._real.snap_keyframe()
-			self._real._set_btt(*now)
-		if btt_to not in self._real._keyframes_times:
-			self._real._set_btt(*btt_to)
-			self._real.snap_keyframe()
-			self._real._set_btt(*now)
+		self._real._set_btt(*btt_from)
+		self._real.snap_keyframe()
 		kf_from = self._real._get_kf(*btt_from)
+		self._real._set_btt(*btt_to)
+		self._real.snap_keyframe()
 		kf_to = self._real._get_kf(*btt_to)
+		self._real._set_btt(*now)
 		keys = []
 		values_from = []
 		values_to = []
@@ -701,7 +698,10 @@ class EngineHandle(object):
 				assert k[0] == 'graph'
 				_, graph, key = k
 				graph, key = map(pack, (graph, key))
-				delta[graph][key] = v
+				if graph in delta:
+					delta[graph][key] = v
+				else:
+					delta[graph] = {key: v}
 		for graph in kf_from['nodes'].keys() & kf_to['nodes'].keys():
 			for node in kf_from['nodes'][graph].keys(
 			) - kf_to['nodes'][graph].keys():

--- a/LiSE/LiSE/handle.py
+++ b/LiSE/LiSE/handle.py
@@ -652,28 +652,29 @@ class EngineHandle(object):
 			b = kf_to['graph_val'].get(graph, {})
 			for k in a.keys() | b.keys():
 				keys.append(('graph', graph, k))
-				values_from.append(pack(a.get(k)))
-				values_to.append(pack(b.get(k)))
+				values_from.append(pack(a.get(k)) + b'\xc0')
+				values_to.append(pack(b.get(k)) + b'\xc0')
 		for graph, node in kf_from['node_val'].keys() | kf_to['node_val'].keys(
 		):
 			a = kf_from['node_val'].get((graph, node), {})
 			b = kf_to['node_val'].get((graph, node), {})
 			for k in a.keys() | b.keys():
 				keys.append(('node', graph, node, k))
-				values_from.append(pack(a.get(k)))
-				values_to.append(pack(b.get(k)))
+				values_from.append(pack(a.get(k)) + b'\xc0')
+				values_to.append(pack(b.get(k)) + b'\xc0')
 		for graph, orig, dest, i in kf_from['edge_val'].keys(
 		) | kf_to['edge_val'].keys():
 			a = kf_from['edge_val'].get((graph, orig, dest, i), {})
 			b = kf_to['edge_val'].get((graph, orig, dest, i), {})
 			for k in a.keys() | b.keys():
 				keys.append(('edge', graph, orig, dest, k))
-				values_from.append(pack(a.get(k)))
-				values_to.append(pack(b.get(k)))
+				values_from.append(pack(a.get(k)) + b'\xc0')
+				values_to.append(pack(b.get(k)) + b'\xc0')
 		values_changed = np.array(values_from) != np.array(values_to)
 		delta = {}
 		for k, v, _ in filter(itemgetter(2),
 								zip(keys, values_to, values_changed)):
+			v = v[:-1]
 			if k[0] == 'node':
 				_, graph, node, key = k
 				graph, node, key = map(pack, (graph, node, key))

--- a/LiSE/LiSE/handle.py
+++ b/LiSE/LiSE/handle.py
@@ -651,7 +651,7 @@ class EngineHandle(object):
 			a = kf_from['graph_val'].get(graph, {})
 			b = kf_to['graph_val'].get(graph, {})
 			for k in a.keys() | b.keys():
-				keys.append(('graph', graph, k))
+				keys.append(('graph', graph[0], k))
 				values_from.append(pack(a.get(k)) + b'\xc0')
 				values_to.append(pack(b.get(k)) + b'\xc0')
 		for graph, node in kf_from['node_val'].keys() | kf_to['node_val'].keys(
@@ -706,22 +706,22 @@ class EngineHandle(object):
 		for graph in kf_from['nodes'].keys() & kf_to['nodes'].keys():
 			for node in kf_from['nodes'][graph].keys(
 			) - kf_to['nodes'][graph].keys():
-				graph, node = map(pack, (graph, node))
-				if graph not in delta:
-					delta[graph] = {NODES: {node: FALSE}}
-				elif NODES not in delta[graph]:
-					delta[graph][NODES] = {node: FALSE}
+				grap, node = map(pack, (graph[0], node))
+				if grap not in delta:
+					delta[grap] = {NODES: {node: FALSE}}
+				elif NODES not in delta[grap]:
+					delta[grap][NODES] = {node: FALSE}
 				else:
-					delta[graph][NODES][node] = FALSE
+					delta[grap][NODES][node] = FALSE
 			for node in kf_to['nodes'][graph].keys(
 			) - kf_from['nodes'][graph].keys():
-				graph, node = map(pack, (graph, node))
-				if graph not in delta:
-					delta[graph] = {NODES: {node: TRUE}}
-				elif NODE_VAL not in delta[graph]:
-					delta[graph][NODES] = {node: TRUE}
+				grap, node = map(pack, (graph[0], node))
+				if grap not in delta:
+					delta[grap] = {NODES: {node: TRUE}}
+				elif NODE_VAL not in delta[grap]:
+					delta[grap][NODES] = {node: TRUE}
 				else:
-					delta[graph][NODES][node] = TRUE
+					delta[grap][NODES][node] = TRUE
 		for graph, orig, dest in kf_from['edges'].keys() - kf_to['edges'].keys(
 		):
 			graph = pack(graph)
@@ -1626,7 +1626,7 @@ class EngineHandle(object):
 
 	def del_portal(self, char: Hashable, orig: Hashable,
 					dest: Hashable) -> None:
-		del self._real.character[char].portal[orig][dest]
+		self._real.character[char].remove_edge(orig, dest)
 
 	def set_portal_stat(self, char: Hashable, orig: Hashable, dest: Hashable,
 						k: Hashable, v) -> None:

--- a/LiSE/LiSE/handle.py
+++ b/LiSE/LiSE/handle.py
@@ -702,40 +702,43 @@ class EngineHandle(object):
 				_, graph, key = k
 				graph, key = map(pack, (graph, key))
 				delta[graph][key] = v
-		for graph, node in kf_from['nodes'].keys() - kf_to['nodes'].keys():
-			graph, node = map(pack, (graph, node))
+		for graph in kf_from['nodes'].keys() & kf_to['nodes'].keys():
+			for node in kf_from['nodes'][graph].keys(
+			) - kf_to['nodes'][graph].keys():
+				graph, node = map(pack, (graph, node))
+				if graph not in delta:
+					delta[graph] = {NODES: {node: FALSE}}
+				elif NODES not in delta[graph]:
+					delta[graph][NODES] = {node: FALSE}
+				else:
+					delta[graph][NODES][node] = FALSE
+			for node in kf_to['nodes'][graph].keys(
+			) - kf_from['nodes'][graph].keys():
+				graph, node = map(pack, (graph, node))
+				if graph not in delta:
+					delta[graph] = {NODES: {node: TRUE}}
+				elif NODE_VAL not in delta[graph]:
+					delta[graph][NODES] = {node: TRUE}
+				else:
+					delta[graph][NODES][node] = TRUE
+		for graph, orig, dest in kf_from['edges'].keys() - kf_to['edges'].keys(
+		):
+			graph = pack(graph)
 			if graph not in delta:
-				delta[graph] = {NODE_VAL: {node: NONE}}
-			elif NODE_VAL not in delta[graph]:
-				delta[graph][NODE_VAL] = {node: NONE}
+				delta[graph] = {EDGES: {pack((orig, dest)): FALSE}}
+			elif EDGES not in delta[graph]:
+				delta[graph][EDGES] = {pack((orig, dest)): FALSE}
 			else:
-				delta[graph][NODE_VAL][node] = NONE
-		for graph, node in kf_to['nodes'].keys() - kf_from['nodes'].keys():
-			graph, node = map(pack, (graph, node))
-			if graph not in delta:
-				delta[graph] = {NODE_VAL: {node: {}}}
-			elif NODE_VAL not in delta[graph]:
-				delta[graph][NODE_VAL] = {node: {}}
-		for graph, orig, dest, _ in kf_from['edges'].keys(
-		) - kf_to['edges'].keys():
-			graph, orig, dest = map(pack, (graph, orig, dest))
-			if graph not in delta:
-				delta[graph] = {EDGE_VAL: {orig: {dest: NONE}}}
-			elif EDGE_VAL not in delta[graph]:
-				delta[graph][EDGE_VAL] = {orig: {dest: NONE}}
-			elif orig not in delta[graph][EDGE_VAL]:
-				delta[graph][EDGE_VAL][orig] = {dest: NONE}
-			else:
-				delta[graph][EDGE_VAL][orig][dest] = None
+				delta[graph][EDGES][pack((orig, dest))] = FALSE
 		for graph, orig, dest, _ in kf_to['edges'].keys(
 		) - kf_from['edges'].keys():
-			graph, orig, dest = map(pack, (graph, orig, dest))
+			graph = pack(graph)
 			if graph not in delta:
-				delta[graph] = {EDGE_VAL: {orig: {dest: {}}}}
-			elif EDGE_VAL not in delta[graph]:
-				delta[graph][EDGE_VAL] = {orig: {dest: {}}}
-			elif orig not in delta[graph][EDGE_VAL]:
-				delta[graph][EDGE_VAL][orig] = {dest: {}}
+				delta[graph] = {EDGES: {pack((orig, dest)): TRUE}}
+			elif EDGES not in delta[graph]:
+				delta[graph][EDGES] = {pack((orig, dest)): TRUE}
+			else:
+				delta[graph][EDGES][pack((orig, dest))] = TRUE
 		unid = self.universal_delta(btt_from=btt_from, btt_to=btt_to)
 		if unid:
 			delta[UNIVERSAL] = unid

--- a/LiSE/LiSE/proxy.py
+++ b/LiSE/LiSE/proxy.py
@@ -2383,13 +2383,7 @@ class EngineProxy(AbstractEngine):
 							block=block,
 							cb=partial(self._upd_and_cb, cb))
 
-	def time_travel(self,
-					branch,
-					turn,
-					tick=None,
-					chars='all',
-					cb=None,
-					block=True):
+	def time_travel(self, branch, turn, tick=None, cb=None, block=True):
 		"""Move to a different point in the timestream
 
 		Needs ``branch`` and ``turn`` arguments. The ``tick`` is
@@ -2397,18 +2391,13 @@ class EngineProxy(AbstractEngine):
 		in the turn.
 
 		May take a callback function ``cb``, which will receive a
-		dictionary describing changes to the characters in ``chars``.
-		``chars`` defaults to 'all', indicating that every character
-		should be included, but may be a list of character names
-		to include.
+		dictionary describing changes to the characters.
 
 		With ``block=True`` (the default), wait until finished computing
 		differences before returning. Otherwise my ``branch``, ``turn``,
 		and ``tick`` will stay where they are until that's done.
 
 		"""
-		if cb and not chars:
-			raise TypeError("Callbacks require chars")
 		if cb is not None and not callable(cb):
 			raise TypeError("Uncallable callback")
 		return self.handle('time_travel',
@@ -2416,7 +2405,6 @@ class EngineProxy(AbstractEngine):
 							branch=branch,
 							turn=turn,
 							tick=tick,
-							chars=chars,
 							cb=partial(self._upd_and_cb, cb))
 
 	def add_character(self, char, data={}, block=False, **attr):

--- a/LiSE/LiSE/proxy.py
+++ b/LiSE/LiSE/proxy.py
@@ -210,9 +210,7 @@ class NodeProxy(CachingEntityProxy):
 		self.engine.handle('set_node_rulebook',
 							char=self._charname,
 							node=self.name,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	def __init__(self, character, nodename):
 		self.engine = character.engine
@@ -254,9 +252,7 @@ class NodeProxy(CachingEntityProxy):
 							char=self._charname,
 							node=self.name,
 							k=k,
-							v=v,
-							block=False,
-							branching=True)
+							v=v)
 
 	def _del_item(self, k):
 		if k == 'name':
@@ -264,9 +260,7 @@ class NodeProxy(CachingEntityProxy):
 		self.engine.handle(command='del_node_stat',
 							char=self._charname,
 							node=self.name,
-							k=k,
-							block=False,
-							branching=True)
+							k=k)
 
 	def delete(self):
 		self.engine.del_node(self._charname, self.name)
@@ -345,9 +339,7 @@ class ThingProxy(NodeProxy):
 		self.engine.handle(command='set_thing_location',
 							char=self.character.name,
 							thing=self.name,
-							loc=v,
-							block=False,
-							branching=True)
+							loc=v)
 		self.send(self, key='location', value=v)
 
 	def __setitem__(self, k, v):
@@ -365,8 +357,7 @@ class ThingProxy(NodeProxy):
 							char=self._charname,
 							thing=self.name,
 							path=path,
-							weight=weight,
-							block=False)
+							weight=weight)
 
 	def go_to_place(self, place, weight=None):
 		if hasattr(place, 'name'):
@@ -375,8 +366,7 @@ class ThingProxy(NodeProxy):
 							char=self._charname,
 							thing=self.name,
 							place=place,
-							weight=weight,
-							block=False)
+							weight=weight)
 
 	def travel_to(self, dest, weight=None, graph=None):
 		if hasattr(dest, 'name'):
@@ -401,8 +391,7 @@ class ThingProxy(NodeProxy):
 							dest=dest,
 							arrival_tick=arrival_tick,
 							weight=weight,
-							graph=graph,
-							block=False)
+							graph=graph)
 
 
 Thing.register(ThingProxy)
@@ -427,8 +416,7 @@ class PortalProxy(CachingEntityProxy):
 							char=self._charname,
 							orig=self._origin,
 							dest=self._destination,
-							rulebook=rb,
-							block=False)
+							rulebook=rb)
 
 	def _get_rulebook_name(self):
 		return self.engine.handle(command='get_portal_rulebook',
@@ -466,18 +454,14 @@ class PortalProxy(CachingEntityProxy):
 							orig=self._origin,
 							dest=self._destination,
 							k=k,
-							v=v,
-							block=False,
-							branching=True)
+							v=v)
 
 	def _del_item(self, k):
 		self.engine_handle(command='del_portal_stat',
 							char=self._charname,
 							orig=self._origin,
 							dest=self._destination,
-							k=k,
-							block=False,
-							branching=True)
+							k=k)
 
 	def __init__(self, character, origname, destname):
 		self.engine = character.engine
@@ -530,9 +514,7 @@ class NodeMapProxy(MutableMapping, Signal):
 	def _set_rulebook(self, rb):
 		self.engine.handle('set_character_node_rulebook',
 							char=self._charname,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	@property
 	def character(self):
@@ -581,8 +563,7 @@ class NodeMapProxy(MutableMapping, Signal):
 		"""
 		self.engine.handle('update_nodes',
 							char=self.character.name,
-							patch=patch,
-							block=True)
+							patch=patch)
 		for node, stats in patch.items():
 			nodeproxycache = self[node]._cache
 			for k, v in stats.items():
@@ -608,9 +589,7 @@ class ThingMapProxy(CachingProxy):
 	def _set_rulebook(self, rb):
 		self.engine.handle('set_character_thing_rulebook',
 							char=self.name,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	@property
 	def character(self):
@@ -639,18 +618,12 @@ class ThingMapProxy(CachingProxy):
 		self.engine.handle(command='set_thing',
 							char=self.name,
 							thing=k,
-							statdict=v,
-							block=False,
-							branching=True)
+							statdict=v)
 		self._cache[k] = ThingProxy(self.engine, self.name, v.pop('location'))
 		self.engine._node_stat_cache[self.name][k] = v
 
 	def _del_item(self, k):
-		self.engine.handle(command='del_node',
-							char=self.name,
-							node=k,
-							block=False,
-							branching=True)
+		self.engine.handle(command='del_node', char=self.name, node=k)
 		del self._cache[k]
 		del self.engine._node_stat_cache[self.name][k]
 
@@ -677,9 +650,7 @@ class PlaceMapProxy(CachingProxy):
 	def _set_rulebook(self, rb):
 		self.engine.handle('set_character_place_rulebook',
 							char=self.name,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	@property
 	def character(self):
@@ -704,17 +675,11 @@ class PlaceMapProxy(CachingProxy):
 		self.engine.handle(command='set_place',
 							char=self.name,
 							place=k,
-							statdict=v,
-							block=False,
-							branching=True)
+							statdict=v)
 		self.engine._node_stat_cache[self.name][k] = v
 
 	def _del_item(self, k):
-		self.engine.handle(command='del_node',
-							char=self.name,
-							node=k,
-							block=False,
-							branching=True)
+		self.engine.handle(command='del_node', char=self.name, node=k)
 		del self.engine._node_stat_cache[self.name][k]
 
 	def patch(self, d: dict):
@@ -772,9 +737,7 @@ class SuccessorsProxy(CachingProxy):
 							char=self._charname,
 							orig=self._orig,
 							dest=dest,
-							statdict=value,
-							block=False,
-							branching=True)
+							statdict=value)
 
 	def _del_item(self, dest):
 		self.engine.del_portal(self._charname, self._orig, dest)
@@ -796,9 +759,7 @@ class CharSuccessorsMappingProxy(CachingProxy):
 	def _set_rulebook(self, rb):
 		self.engine.handle('set_character_portal_rulebook',
 							char=self.character.name,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	@property
 	def character(self):
@@ -833,9 +794,7 @@ class CharSuccessorsMappingProxy(CachingProxy):
 		self.engine.handle(command='character_set_node_successors',
 							character=self.name,
 							node=orig,
-							val=val,
-							block=False,
-							branching=True)
+							val=val)
 
 	def _del_item(self, orig):
 		for dest in self[orig]:
@@ -876,12 +835,8 @@ class PredecessorsProxy(MutableMapping):
 		self.engine.handle(command='set_place',
 							char=self._charname,
 							place=k,
-							statdict=v,
-							block=False,
-							branching=True)
-		self.engine.handle('set_portal', (self._charname, k, self.name),
-							block=False,
-							branching=True)
+							statdict=v)
+		self.engine.handle('set_portal', (self._charname, k, self.name))
 
 	def __delitem__(self, k):
 		self.engine.del_portal(self._charname, k, self.name)
@@ -918,9 +873,7 @@ class CharPredecessorsMappingProxy(MutableMapping):
 		self.engine.handle(command='character_set_node_predecessors',
 							char=self.name,
 							node=k,
-							preds=v,
-							block=False,
-							branching=True)
+							preds=v)
 
 	def __delitem__(self, k):
 		for v in list(self[k]):
@@ -961,16 +914,10 @@ class CharStatProxy(CachingEntityProxy):
 		self.engine.handle(command='set_character_stat',
 							char=self.name,
 							k=k,
-							v=v,
-							block=True,
-							branching=True)
+							v=v)
 
 	def _del_item(self, k):
-		self.engine.handle(command='del_character_stat',
-							char=self.name,
-							k=k,
-							block=True,
-							branching=True)
+		self.engine.handle(command='del_character_stat', char=self.name, k=k)
 
 
 class RuleProxy(Signal):
@@ -999,8 +946,7 @@ class RuleProxy(Signal):
 		self._cache['triggers'] = v
 		self.engine.handle('set_rule_triggers',
 							rule=self.name,
-							triggers=self._nominate(v),
-							block=False)
+							triggers=self._nominate(v))
 		self.send(self, triggers=v)
 
 	@property
@@ -1012,8 +958,7 @@ class RuleProxy(Signal):
 		self._cache['prereqs'] = v
 		self.engine.handle('set_rule_prereqs',
 							rule=self.name,
-							prereqs=self._nominate(v),
-							block=False)
+							prereqs=self._nominate(v))
 		self.send(self, prereqs=v)
 
 	@property
@@ -1025,8 +970,7 @@ class RuleProxy(Signal):
 		self._cache['actions'] = v
 		self.engine.handle('set_rule_actions',
 							rule=self.name,
-							actions=self._nominate(v),
-							block=False)
+							actions=self._nominate(v))
 		self.send(self, actions=v)
 
 	def __init__(self, engine, rulename):
@@ -1072,18 +1016,14 @@ class RuleBookProxy(MutableSequence, Signal):
 		self.engine.handle(command='set_rulebook_rule',
 							rulebook=self.name,
 							i=i,
-							rule=v,
-							block=False,
-							branching=True)
+							rule=v)
 		self.send(self, i=i, val=v)
 
 	def __delitem__(self, i):
 		del self._cache[i]
 		self.engine.handle(command='del_rulebook_rule',
 							rulebook=self.name,
-							i=i,
-							block=False,
-							branching=True)
+							i=i)
 		self.send(self, i=i, val=None)
 
 	def insert(self, i, v):
@@ -1093,9 +1033,7 @@ class RuleBookProxy(MutableSequence, Signal):
 		self.engine.handle(command='ins_rulebook_rule',
 							rulebook=self.name,
 							i=i,
-							rule=v,
-							block=False,
-							branching=True)
+							rule=v)
 		for j in range(i, len(self)):
 			self.send(self, i=j, val=self[j])
 
@@ -1118,9 +1056,7 @@ class UnitMapProxy(Mapping):
 	def _set_rulebook(self, rb):
 		self.engine.handle('set_unit_rulebook',
 							char=self.character.name,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	def __init__(self, character):
 		self.character = character
@@ -1197,9 +1133,7 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle('character_copy_from',
 							char=self.name,
 							nodes=g._node,
-							adj=g._adj,
-							block=False,
-							branching=True)
+							adj=g._adj)
 		for node, nodeval in g.nodes.items():
 			if node not in self.node:
 				if nodeval and 'location' in nodeval:
@@ -1237,9 +1171,7 @@ class CharacterProxy(AbstractCharacter):
 	def _set_rulebook(self, rb):
 		self.engine.handle('set_character_rulebook',
 							char=self.name,
-							rulebook=rb,
-							block=False,
-							branching=True)
+							rulebook=rb)
 
 	@cached_property
 	def unit(self):
@@ -1312,8 +1244,11 @@ class CharacterProxy(AbstractCharacter):
 				self.engine._character_portals_cache.store(
 					self.name, orig, dest, PortalProxy(self, orig, dest))
 			else:
-				self.engine._character_portals_cache.delete(
-					self.name, orig, dest)
+				try:
+					self.engine._character_portals_cache.delete(
+						self.name, orig, dest)
+				except KeyError:
+					pass
 		self.portal._apply_delta(delta.pop('edge_val', {}))
 		nodemap = self.node
 		name = self.name
@@ -1366,18 +1301,14 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle(command='set_place',
 							char=self.name,
 							place=name,
-							statdict=kwargs,
-							block=False,
-							branching=True)
+							statdict=kwargs)
 		self.place._cache[name] = PlaceProxy(self, name)
 		self.engine._node_stat_cache[self.name][name] = kwargs
 
 	def add_places_from(self, seq):
 		self.engine.handle(command='add_places_from',
 							char=self.name,
-							seq=list(seq),
-							block=False,
-							branching=True)
+							seq=list(seq))
 		placecache = self.place._cache
 		nodestatcache = self.engine._node_stat_cache[self.name]
 		for pln in seq:
@@ -1396,17 +1327,13 @@ class CharacterProxy(AbstractCharacter):
 							char=self.name,
 							thing=name,
 							loc=location,
-							statdict=kwargs,
-							block=False,
-							branching=True)
+							statdict=kwargs)
 		self.thing._cache[name] = ThingProxy(self, name, location, **kwargs)
 
 	def add_things_from(self, seq, **attrs):
 		self.engine.handle(command='add_things_from',
 							char=self.name,
-							seq=list(seq),
-							block=False,
-							branching=True)
+							seq=list(seq))
 		for name, location in seq:
 			self.thing._cache[name] = ThingProxy(self, name, location)
 
@@ -1414,11 +1341,7 @@ class CharacterProxy(AbstractCharacter):
 		if node not in self.node:
 			raise KeyError("No such node: {}".format(node))
 		name = self.name
-		self.engine.handle('del_node',
-							char=name,
-							node=node,
-							block=False,
-							branching=True)
+		self.engine.handle('del_node', char=name, node=node)
 		placecache = self.place._cache
 		thingcache = self.thing._cache
 		if node in placecache:
@@ -1441,11 +1364,7 @@ class CharacterProxy(AbstractCharacter):
 		if place not in placemap:
 			raise KeyError("No such place: {}".format(place))
 		name = self.name
-		self.engine.handle('del_node',
-							char=name,
-							node=place,
-							block=False,
-							branching=True)
+		self.engine.handle('del_node', char=name, node=place)
 		del placemap._cache[place]
 		portscache = self.engine._character_portals_cache
 		del portscache.successors[name][place]
@@ -1456,11 +1375,7 @@ class CharacterProxy(AbstractCharacter):
 		if thing not in thingmap:
 			raise KeyError("No such thing: {}".format(thing))
 		name = self.name
-		self.engine.handle('del_node',
-							char=name,
-							node=thing,
-							block=False,
-							branching=True)
+		self.engine.handle('del_node', char=name, node=thing)
 		del thingmap._cache[thing]
 		portscache = self.engine._character_portals_cache
 		del portscache.successors[name][thing]
@@ -1471,9 +1386,7 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle(command='place2thing',
 							char=self.name,
 							node=node,
-							loc=location,
-							block=False,
-							branching=True)
+							loc=location)
 
 	def add_portal(self, origin, destination, symmetrical=False, **kwargs):
 		self.engine.handle(command='add_portal',
@@ -1481,9 +1394,7 @@ class CharacterProxy(AbstractCharacter):
 							orig=origin,
 							dest=destination,
 							symmetrical=symmetrical,
-							statdict=kwargs,
-							block=False,
-							branching=True)
+							statdict=kwargs)
 		self.engine._character_portals_cache.store(
 			self.name, origin, destination,
 			PortalProxy(self, origin, destination))
@@ -1510,9 +1421,7 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle('del_portal',
 							char=self.name,
 							orig=origin,
-							dest=destination,
-							block=False,
-							branching=True)
+							dest=destination)
 		char_port_cache.delete(self.name, origin, destination)
 
 	remove_edge = remove_portal
@@ -1522,9 +1431,7 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle(command='add_portals_from',
 							char=self.name,
 							seq=l,
-							symmetrical=symmetrical,
-							block=False,
-							branching=True)
+							symmetrical=symmetrical)
 		for (origin, destination) in l:
 			if origin not in self.portal._cache:
 				self.portal._cache[origin] = SuccessorsProxy(
@@ -1544,9 +1451,7 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle(command='add_unit',
 							char=self.name,
 							graph=graph,
-							node=node,
-							block=False,
-							branching=True)
+							node=node)
 
 	def remove_unit(self, graph, node=None):
 		# TODO: cache
@@ -1556,9 +1461,7 @@ class CharacterProxy(AbstractCharacter):
 		self.engine.handle(command='remove_unit',
 							char=self.name,
 							graph=graph,
-							node=node,
-							block=False,
-							branching=True)
+							node=node)
 
 	def units(self):
 		yield from self.engine.handle(command='character_units',
@@ -1602,19 +1505,12 @@ class CharacterMapProxy(MutableMapping, Signal):
 		return self.engine._char_cache[k]
 
 	def __setitem__(self, k, v):
-		self.engine.handle(command='set_character',
-							char=k,
-							data=v,
-							block=False,
-							branching=True)
+		self.engine.handle(command='set_character', char=k, data=v)
 		self.engine._char_cache[k] = CharacterProxy(self.engine, k)
 		self.send(self, key=k, val=v)
 
 	def __delitem__(self, k):
-		self.engine.handle(command='del_character',
-							char=k,
-							block=False,
-							branching=True)
+		self.engine.handle(command='del_character', char=k)
 		if k in self.engine._char_cache:
 			del self.engine._char_cache[k]
 		self.send(self, key=k, val=None)
@@ -1743,16 +1639,12 @@ class GlobalVarProxy(MutableMapping, Signal):
 
 	def __setitem__(self, k, v):
 		self._cache[k] = v
-		self.engine.handle('set_universal',
-							k=k,
-							v=v,
-							block=False,
-							branching=True)
+		self.engine.handle('set_universal', k=k, v=v)
 		self.send(self, key=k, value=v)
 
 	def __delitem__(self, k):
 		del self._cache[k]
-		self.engine.handle('del_universal', k=k, block=False, branching=True)
+		self.engine.handle('del_universal', k=k)
 		self.send(self, key=k, value=None)
 
 	def _update_cache(self, data):
@@ -2047,7 +1939,6 @@ class EngineProxy(AbstractEngine):
 		self._handle_out_lock = Lock()
 		self._handle_in = handle_in
 		self._handle_in_lock = Lock()
-		self._handle_lock = Lock()
 		self._commit_lock = Lock()
 		self.logger = logger
 
@@ -2154,143 +2045,56 @@ class EngineProxy(AbstractEngine):
 
 		The only positional argument should be the name of a
 		method in :class:``EngineHandle``. All keyword arguments
-		will be passed to it, with the exceptions of
-		``cb``, ``branching``, and ``silent``.
+		will be passed to it, with the exception of ``cb``.
 
-		With ``block=False``, don't wait for a result.
-		This is best for when you want to make some change to the game
-		state and already know what effect it will have.
+        I handle paradoxes by creating new branches of history. I will
+        switch to the new branch if needed. If I have an attribute
+        ``branching_cb``, I'll call it if and only if the branch changes
+        upon completing a command.
 
-		With ``branching=True``, handle paradoxes by creating new
-		branches of history. I will switch to the new branch if needed.
-		If I have an attribute ``branching_cb``, I'll call it if and
-		only if the branch changes upon completing a command with
-		``branching=True``.
-
-		With a function ``cb``, I will call ``cb`` when I get
-		a result. If ``block=False`` this will happen in a thread.
-		``cb`` will be called with keyword arguments ``command``,
-		the same command you asked for; ``result``, the value returned
-		by it, possibly ``None``; and the present ``branch``,
-		``turn``, and ``tick``, possibly different than when you called
-		``handle``.
-
-		If any of ``branching``, ``cb``, or ``future`` are ``True``,
-		I will return a ``Future``. The ``Future``'s return value
-		is a tuple of ``(command, branch, turn, tick, result)``.
+		With a function ``cb``, I will call ``cb`` when I get a result.
+		``cb`` will be called with keyword arguments ``command``, the same
+		command you asked for; ``result``, the value returned by it, possibly
+		``None``; and the present ``branch``, ``turn``, and ``tick``,
+		possibly different than when you called ``handle``.
 
 		"""
 		if self.closed:
 			raise RedundantProcessError(f"Already closed: {id(self)}")
+		for bad in ['silent', 'block', 'future', 'branching']:
+			assert not kwargs.get(
+				bad), "Too complicated, removed functionality"
 		if 'command' in kwargs:
 			cmd = kwargs['command']
 		elif cmd:
 			kwargs['command'] = cmd
 		else:
 			raise TypeError("No command")
-		branching = kwargs.get('branching', False)
 		cb = kwargs.pop('cb', None)
-		future = kwargs.pop('future', False)
-		self._handle_lock.acquire()
-		if kwargs.pop('block', True):
-			assert not kwargs.get('silent')
-			self.debug('EngineProxy: sending {}'.format(kwargs))
-			self.send_bytes(self.pack(kwargs))
-			received = self.recv_bytes()
-			command, branch, turn, tick, r = self.unpack(received)
-			assert cmd == command, "Sent command {} but received results for {}".format(
-				cmd, command)
-			self.debug('EngineProxy: received {}'.format(
-				(command, branch, turn, tick, r)))
-			if (branch, turn, tick) != self._btt():
-				self._branch = branch
-				self._turn = turn
-				self._tick = tick
-				self.time.send(self, branch=branch, turn=turn, tick=tick)
-			if isinstance(r, Exception):
-				self._handle_lock.release()
-				raise r
-			if cb:
-				cb(command=command,
-					branch=branch,
-					turn=turn,
-					tick=tick,
-					result=r)
-			self._handle_lock.release()
-			return r
-		else:
-			kwargs['silent'] = not (branching or cb or future)
-			self.debug('EngineProxy: asynchronously sending {}'.format(kwargs))
-			self.send_bytes(self.pack(kwargs))
-			if branching:
-				# what happens if more than one branching call
-				# is happening at once?
-				return self._submit(self._branching, cb)
-			elif cb:
-				return self._submit(self._callback, cb)
-			if future:
-				return self._submit(self._unpack_recv)
-		self._handle_lock.release()
-
-	def _unpack_recv(self):
-		ret = self.unpack(self.recv_bytes())
-		self._handle_lock.release()
-		return ret
-
-	def _callback(self, cb):
-		command, branch, turn, tick, res = self.unpack(self.recv_bytes())
-		self._handle_lock.release()
-		self.debug('EngineProxy: received, with callback {}: {}'.format(
-			cb, (command, branch, turn, tick, res)))
-		ex = None
-		if isinstance(res, Exception):
-			ex = res
-		try:
-			if isinstance(res[0], Exception):
-				ex = res[0]
-		except TypeError:
-			pass
-		if ex:
-			self.warning(
-				"{} raised by command {}, trying to run callback {} with it".
-				format(repr(ex), command, cb))
-		cb(command=command, branch=branch, turn=turn, tick=tick, result=res)
-		return command, branch, turn, tick, res
-
-	def _branching(self, cb=None):
+		self.debug('EngineProxy: sending {}'.format(kwargs))
+		self.send_bytes(self.pack(kwargs))
 		command, branch, turn, tick, r = self.unpack(self.recv_bytes())
-		self._handle_lock.release()
-		self.debug('EngineProxy: received, with branching, {}'.format(
+		assert cmd == command, "Sent command {} but received results for {}".format(
+			cmd, command)
+		self.debug('EngineProxy: received {}'.format(
 			(command, branch, turn, tick, r)))
-		if (branch, turn, tick) != (self._branch, self._turn, self._tick):
+		if isinstance(r, Exception):
+			raise r
+
+		if branch != self.branch and hasattr(self, 'branching_cb'):
+			self.branching_cb(command=command,
+								branch=branch,
+								turn=turn,
+								tick=tick,
+								result=r)
+		if cb:
+			cb(command=command, branch=branch, turn=turn, tick=tick, result=r)
+		if (branch, turn, tick) != self._btt():
 			self._branch = branch
 			self._turn = turn
 			self._tick = tick
 			self.time.send(self, branch=branch, turn=turn, tick=tick)
-			if hasattr(self, 'branching_cb'):
-				self.branching_cb(command=command,
-									branch=branch,
-									turn=turn,
-									tick=tick,
-									result=r)
-		if cb:
-			cb(command=command, branch=branch, turn=turn, tick=tick, result=r)
-		return command, branch, turn, tick, r
-
-	def _call_with_recv(self, *cbs, **kwargs):
-		cmd, branch, turn, tick, received = self.unpack(self.recv_bytes())
-		self.debug('EngineProxy: received {}'.format(
-			(cmd, branch, turn, tick, received)))
-		if isinstance(received, Exception):
-			raise received
-		for cb in cbs:
-			cb(command=cmd,
-				branch=branch,
-				turn=turn,
-				tick=tick,
-				result=received,
-				**kwargs)
-		return received
+		return r
 
 	def _upd_caches(self, command, branch, turn, tick, result, no_del=False):
 		deleted = set(self.character.keys())
@@ -2344,30 +2148,13 @@ class EngineProxy(AbstractEngine):
 	def is_parent_of(self, parent, child):
 		return self.handle('is_parent_of', parent=parent, child=child)
 
-	def _pull_async(self, chars, cb):
-		if not callable(cb):
-			raise TypeError("Uncallable callback")
-		self.send_bytes(
-			self.pack({
-				'silent': False,
-				'command': 'get_char_deltas',
-				'chars': chars
-			}))
-		cbs = [self._upd_caches]
-		if cb:
-			cbs.append(cb)
-		self._call_with_recv(cbs)
-
-	def pull(self, chars='all', cb=None, block=True):
+	def pull(self, chars='all', cb=None):
 		"""Update the state of all my proxy objects from the real objects."""
-		if block:
-			deltas = self.handle('get_char_deltas',
-									chars=chars,
-									cb=self._upd_deltas)
-			if cb:
-				cb(deltas)
-		else:
-			return self._submit(self._pull_async, chars, cb)
+		deltas = self.handle('get_char_deltas',
+								chars=chars,
+								cb=self._upd_deltas)
+		if cb:
+			cb(deltas)
 
 	def _upd_and_cb(self, cb, *args, **kwargs):
 		self._upd_caches(*args, no_del=True, **kwargs)
@@ -2376,14 +2163,12 @@ class EngineProxy(AbstractEngine):
 			cb(*args, **kwargs)
 
 	# TODO: make this into a Signal, like it is in the LiSE core
-	def next_turn(self, cb=None, block=False):
+	def next_turn(self, cb=None):
 		if cb and not callable(cb):
 			raise TypeError("Uncallable callback")
-		return self.handle('next_turn',
-							block=block,
-							cb=partial(self._upd_and_cb, cb))
+		return self.handle('next_turn', cb=partial(self._upd_and_cb, cb))
 
-	def time_travel(self, branch, turn, tick=None, cb=None, block=True):
+	def time_travel(self, branch, turn, tick=None, cb=None):
 		"""Move to a different point in the timestream
 
 		Needs ``branch`` and ``turn`` arguments. The ``tick`` is
@@ -2393,21 +2178,16 @@ class EngineProxy(AbstractEngine):
 		May take a callback function ``cb``, which will receive a
 		dictionary describing changes to the characters.
 
-		With ``block=True`` (the default), wait until finished computing
-		differences before returning. Otherwise my ``branch``, ``turn``,
-		and ``tick`` will stay where they are until that's done.
-
 		"""
 		if cb is not None and not callable(cb):
 			raise TypeError("Uncallable callback")
 		return self.handle('time_travel',
-							block=block,
 							branch=branch,
 							turn=turn,
 							tick=tick,
 							cb=partial(self._upd_and_cb, cb))
 
-	def add_character(self, char, data={}, block=False, **attr):
+	def add_character(self, char, data={}, **attr):
 		if char in self._char_cache:
 			raise KeyError("Character already exists")
 		assert char not in self._char_stat_cache
@@ -2454,15 +2234,10 @@ class EngineProxy(AbstractEngine):
 					char, orig, dest,
 					PortalProxy(self.character[char], orig, dest))
 				self._portal_stat_cache[char][orig][dest] = stats
-		self.handle(command='add_character',
-					char=char,
-					data=data,
-					attr=attr,
-					block=block,
-					branching=True)
+		self.handle(command='add_character', char=char, data=data, attr=attr)
 
 	def new_character(self, char, **attr):
-		self.add_character(char, block=True, **attr)
+		self.add_character(char, **attr)
 		return self._char_cache[char]
 
 	new_graph = new_character
@@ -2475,10 +2250,7 @@ class EngineProxy(AbstractEngine):
 		del self._character_places_cache[char]
 		del self._things_cache[char]
 		self._character_portals_cache.delete_char(char)
-		self.handle(command='del_character',
-					char=char,
-					block=False,
-					branching=True)
+		self.handle(command='del_character', char=char)
 
 	del_graph = del_character
 
@@ -2492,26 +2264,17 @@ class EngineProxy(AbstractEngine):
 			del self._things_cache[char][node]
 		if node in self._character_places_cache[char]:  # just to be safe
 			del self._character_places_cache[char][node]
-		self.handle(command='del_node',
-					char=char,
-					node=node,
-					block=False,
-					branching=True)
+		self.handle(command='del_node', char=char, node=node)
 
 	def del_portal(self, char, orig, dest):
 		if char not in self._char_cache:
 			raise KeyError("No such character")
 		self._character_portals_cache.delete(char, orig, dest)
-		self.handle(command='del_portal',
-					char=char,
-					orig=orig,
-					dest=dest,
-					block=False,
-					branching=True)
+		self.handle(command='del_portal', char=char, orig=orig, dest=dest)
 
 	def commit(self):
 		self._commit_lock.acquire()
-		self.handle('commit', block=False, cb=self._release_commit_lock)
+		self.handle('commit', cb=self._release_commit_lock)
 
 	def _release_commit_lock(self, *, command, branch, turn, tick, result):
 		self._commit_lock.release()
@@ -2547,15 +2310,11 @@ def subprocess(args, kwargs, handle_out_pipe, handle_in_pipe, logq, loglevel):
 		silent = instruction.pop('silent', False)
 		cmd = instruction.pop('command')
 
-		branching = instruction.pop('branching', False)
 		try:
-			if branching:
-				try:
-					r = getattr(engine_handle, cmd)(**instruction)
-				except HistoricKeyError:
-					engine_handle.increment_branch()
-					r = getattr(engine_handle, cmd)(**instruction)
-			else:
+			try:
+				r = getattr(engine_handle, cmd)(**instruction)
+			except HistoricKeyError:
+				engine_handle.increment_branch()
 				r = getattr(engine_handle, cmd)(**instruction)
 		except AssertionError:
 			raise

--- a/LiSE/LiSE/xcollections.py
+++ b/LiSE/LiSE/xcollections.py
@@ -404,6 +404,8 @@ class CharacterMapping(MutableMapping, Signal):
 		"""Delete the named character from both the cache and the database."""
 		del self.engine._graph_objs[name]
 		self.engine.query.del_graph(name)
+		for cache in self.engine._char_caches:
+			cache.remove_character(name)
 		self.send(self, key=name, val=None)
 
 

--- a/LiSE/LiSE/xcollections.py
+++ b/LiSE/LiSE/xcollections.py
@@ -402,8 +402,6 @@ class CharacterMapping(MutableMapping, Signal):
 
 	def __delitem__(self, name):
 		"""Delete the named character from both the cache and the database."""
-		it = self[name]
-		it.clear()
 		del self.engine._graph_objs[name]
 		self.engine.query.del_graph(name)
 		self.send(self, key=name, val=None)


### PR DESCRIPTION
Instead of iterating over LiSE objects to find the delta between the origin and destination times, this makes LiSE perform that operation on keyframes, which are faster to make and to iterate over.

I also came up with a trick to do the whole thing in two numpy arrays.

Removes some proxy features that were getting in the way. Not sure how they weren't causing problems before. Likewise, deleting characters was always broken and somehow didn't show up in the tests before now, but is fixed.